### PR TITLE
chore: enable SQL data initialization and SQL logging

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,23 +1,22 @@
 spring.application.name=lifemasters
 
-### MYSQL CONFIG ###
+## MYSQL :: Datasource configuration ##
 #spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 #spring.datasource.url=jdbc:mysql://localhost:3306/app_db?useSSL=false&serverTimezone=UTC
 #spring.datasource.username=root
 #spring.datasource.password=root
 
-## HIBERNATE CONFIG for mysql
-#spring.jpa.hibernate.ddl-auto=update
-#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-
-
-### POSTGRES CONFIG ###
+## POSTGRES :: Datasource configuration ##
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://localhost:5432/appdb
 spring.datasource.username=postgres
 spring.datasource.password=postgres
 
-## HIBERNATE CONFIG for postgres
+## JPA CONFIGURATION
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.defer-datasource-initialization=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# Initialize SQL script during application startup
+spring.sql.init.mode=always

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,7 +1,7 @@
---TABLE OPS
---SELECT * FROM <table-name>; --view data
---DROP TABLE <table-name>; --delete table
---TRUNCATE TABLE <table-name>; --clear data
+-- TABLE OPS
+-- SELECT * FROM <table-name>; --view data
+-- DROP TABLE <table-name>; --delete table
+-- TRUNCATE TABLE <table-name>; --clear data
 
 -- USERS
 INSERT INTO users (username, password, email, level, title)


### PR DESCRIPTION
Configured `spring.sql.init.mode=always` to ensure the `data.sql` script is always executed during application startup. Additionally, enabled SQL logging by setting `spring.jpa.show-sql=true` and `spring.jpa.properties.hibernate.format_sql=true` to assist with debugging and visibility of executed SQL queries.